### PR TITLE
(1-2)(1-3)管理者登録画面にて、エラーメッセージを表示するようにしました

### DIFF
--- a/src/views/RegisterAdmin.vue
+++ b/src/views/RegisterAdmin.vue
@@ -87,6 +87,12 @@ export default class RegisterAdmin extends Vue {
   private password = "";
   //エラーメッセージ
   private errorMessage = "";
+  //名前エラー
+  private nameErrorMessage = false;
+  //メールアドレスエラー
+  private mailErrorMessage = false;
+  //パスワードエラー
+  private passErrorMessage = false;
 
   /**
    * 管理者情報を登録する.
@@ -96,7 +102,25 @@ export default class RegisterAdmin extends Vue {
    * @returns Promiseオブジェクト
    */
   async registerAdmin(): Promise<void> {
+    //エラー表示
     this.errorMessage = "";
+    if (this.lastName === "" || this.firstName === "") {
+      this.nameErrorMessage = true;
+    }
+    if (this.mailAddress === "") {
+      this.mailErrorMessage = true;
+    }
+    if (this.password === "") {
+      this.passErrorMessage = true;
+    }
+
+    if (
+      this.nameErrorMessage ||
+      this.mailErrorMessage ||
+      this.passErrorMessage
+    ) {
+      return;
+    }
     // 管理者登録処理
     const response = await axios.post(`${config.EMP_WEBAPI_URL}/insert`, {
       name: this.lastName + " " + this.firstName,

--- a/src/views/RegisterAdmin.vue
+++ b/src/views/RegisterAdmin.vue
@@ -2,6 +2,13 @@
   <div class="container">
     <div class="row register-page">
       <div class="error">{{ errorMessage }}</div>
+      <div class="error" v-show="nameErrorMessage">名前を入力して下さい</div>
+      <div class="error" v-show="mailErrorMessage">
+        メールアドレスを入力して下さい
+      </div>
+      <div class="error" v-show="passErrorMessage">
+        パスワードを入力して下さい
+      </div>
       <form class="col s12" id="reg-form">
         <div class="row">
           <div class="input-field col s6">
@@ -104,6 +111,9 @@ export default class RegisterAdmin extends Vue {
   async registerAdmin(): Promise<void> {
     //エラー表示
     this.errorMessage = "";
+    this.nameErrorMessage = false;
+    this.mailErrorMessage = false;
+    this.passErrorMessage = false;
     if (this.lastName === "" || this.firstName === "") {
       this.nameErrorMessage = true;
     }

--- a/src/views/RegisterAdmin.vue
+++ b/src/views/RegisterAdmin.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="container">
     <div class="row register-page">
+      <div class="error">{{ errorMessage }}</div>
       <form class="col s12" id="reg-form">
         <div class="row">
           <div class="input-field col s6">
@@ -84,6 +85,8 @@ export default class RegisterAdmin extends Vue {
   private mailAddress = "";
   // パスワード
   private password = "";
+  //エラーメッセージ
+  private errorMessage = "";
 
   /**
    * 管理者情報を登録する.
@@ -93,6 +96,7 @@ export default class RegisterAdmin extends Vue {
    * @returns Promiseオブジェクト
    */
   async registerAdmin(): Promise<void> {
+    this.errorMessage = "";
     // 管理者登録処理
     const response = await axios.post(`${config.EMP_WEBAPI_URL}/insert`, {
       name: this.lastName + " " + this.firstName,
@@ -101,7 +105,11 @@ export default class RegisterAdmin extends Vue {
     });
     console.dir("response:" + JSON.stringify(response));
 
-    this.$router.push("/loginAdmin");
+    if (response.data.status === "success") {
+      this.$router.push("/loginAdmin");
+    } else {
+      this.errorMessage = "登録に失敗しました(" + response.data.message + ")";
+    }
   }
 }
 </script>
@@ -109,5 +117,8 @@ export default class RegisterAdmin extends Vue {
 <style scoped>
 .register-page {
   width: 600px;
+}
+.error {
+  color: red;
 }
 </style>


### PR DESCRIPTION
1-2を行うつもりでしたが、1-3まで処理してしまったのでお手数ですが2件同時にレビュー頂けると幸いです。
(1-2)初級 入力値エラー処理　：名前、メールアドレス、パスワードが空欄の場合エラーを表示するようにしました。
(1-3)中級 Eメール重複チェック：APIのPOSTが失敗した場合、エラーを表示するようにしました。
こちらの2件対応済です。宜しくお願い致します。